### PR TITLE
Change version dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,8 +10,8 @@ typing-extensions==3.7.4.3
 yarl==1.6.3
 aiofiles==0.6.0
 httptools==0.2.0
-sanic==21.3.4
-sanic-routing==0.6.2
+sanic>=21.3.4
+sanic-routing>=0.6.2
 ujson==4.0.2
 uvloop==0.15.2
-websockets==9.1
+websockets>=9.0


### PR DESCRIPTION
We had to change version dependencies for the carbon minimiser server to make pip install work. We chose to make the dependencies less restrictive.